### PR TITLE
Register missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "duplexify": "^4.1.1",
     "end-of-stream": "^1.4.4",
     "https-proxy-agent": "^5.0.0",
+    "object-assign": "^4.1.1",
     "socket.io-client": "^2.3.0",
     "socket.io-stream": "^0.9.1",
     "winston": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   "dependencies": {
     "@tencent-sdk/capi": "^0.2.15-alpha.0",
     "dijkstrajs": "^1.0.1",
+    "dot-qs": "0.2.0",
     "duplexify": "^4.1.1",
     "end-of-stream": "^1.4.4",
     "https-proxy-agent": "^5.0.0",
     "socket.io-client": "^2.3.0",
     "socket.io-stream": "^0.9.1",
-    "winston": "^3.2.1",
-    "dot-qs": "0.2.0"
+    "winston": "^3.2.1"
   },
   "devDependencies": {
     "babel-eslint": "9.0.0",


### PR DESCRIPTION
`object-assign` is used, while it was not listed as dependency:
https://github.com/serverless/utils-china/blob/9a124d1158c54f80db934e32b76c4d2a11c6bb1f/library/tencent-cloud/client.js#L1

It currently works only by chance that some other dependency in a projects depends on it.
